### PR TITLE
Sign-aware Op Value Predemotion

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -162,6 +162,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
     passManager.addPass(IREE::Util::createPromoteF16ToF32Pass());
   }
   if (clDemoteI64ToI32) {
+    passManager.addPass(IREE::Util::createSignednessPrepI64ToI32Pass());
     passManager.addPass(IREE::Util::createDemoteI64ToI32Pass());
   }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
@@ -30,6 +30,8 @@ std::unique_ptr<OperationPass<void>> createStripDebugOpsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createDemoteI64ToI32Pass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createDemoteF32ToF16Pass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createDemoteF64ToF32Pass();
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createSignednessPrepI64ToI32Pass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createPromoteF16ToF32Pass();
 
 // Test passes.


### PR DESCRIPTION
Implements a pass that checks an op is signed, and has constant
operands. If condition is fufilled, then will "predemote" the value into
the value of signed target type while keeping the source type. This is
to ensure correct demotion of value based on the signedness of ops.