### PR TITLE
Enable vulkan rgp support

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/direct_command_queue.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/direct_command_queue.cc
@@ -22,8 +22,11 @@ namespace vulkan {
 
 DirectCommandQueue::DirectCommandQueue(
     VkDeviceHandle* logical_device,
-    iree_hal_command_category_t supported_categories, VkQueue queue)
-    : CommandQueue(logical_device, supported_categories, queue) {}
+    iree_hal_command_category_t supported_categories, VkQueue queue,
+    bool use_rgp)
+    : CommandQueue(logical_device, supported_categories, queue) {
+  this->enable_rgp = use_rgp;
+}
 
 DirectCommandQueue::~DirectCommandQueue() = default;
 
@@ -108,13 +111,43 @@ iree_status_t DirectCommandQueue::Submit(
                                             &timeline_submit_infos[i], &arena));
   }
 
-  iree_slim_mutex_lock(&queue_mutex_);
-  iree_status_t status = VK_RESULT_TO_STATUS(
-      syms()->vkQueueSubmit(queue_, static_cast<uint32_t>(submit_infos.size()),
-                            submit_infos.data(), VK_NULL_HANDLE),
-      "vkQueueSubmit");
-  iree_slim_mutex_unlock(&queue_mutex_);
-  IREE_RETURN_IF_ERROR(status);
+  iree_status_t status;
+  if (enable_rgp) {
+    VkDebugUtilsLabelEXT vkDebugUtilLabelEnd = {};
+    vkDebugUtilLabelEnd.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+    vkDebugUtilLabelEnd.pNext = nullptr;
+    vkDebugUtilLabelEnd.pLabelName = "AmdFrameEnd";
+
+    VkDebugUtilsLabelEXT vkDebugUtilLabelBegin = {};
+    vkDebugUtilLabelBegin.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+    vkDebugUtilLabelBegin.pNext = nullptr;
+    vkDebugUtilLabelBegin.pLabelName = "AmdFrameBegin";
+
+    iree_slim_mutex_lock(&queue_mutex_);
+
+    // for (int j = 0; j < 10; j++) {
+    while (true) {
+      syms()->vkQueueInsertDebugUtilsLabelEXT(queue_, &vkDebugUtilLabelBegin);
+
+      status = VK_RESULT_TO_STATUS(
+          syms()->vkQueueSubmit(queue_,
+                                static_cast<uint32_t>(submit_infos.size()),
+                                submit_infos.data(), VK_NULL_HANDLE),
+          "vkQueueSubmit");
+
+      syms()->vkQueueWaitIdle(queue_);
+      syms()->vkQueueInsertDebugUtilsLabelEXT(queue_, &vkDebugUtilLabelEnd);
+    }
+
+    iree_slim_mutex_unlock(&queue_mutex_);
+    IREE_RETURN_IF_ERROR(status);
+  } else {
+    status = VK_RESULT_TO_STATUS(
+        syms()->vkQueueSubmit(queue_,
+                              static_cast<uint32_t>(submit_infos.size()),
+                              submit_infos.data(), VK_NULL_HANDLE),
+        "vkQueueSubmit");
+  }
 
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/vulkan/direct_command_queue.h
+++ b/runtime/src/iree/hal/drivers/vulkan/direct_command_queue.h
@@ -22,7 +22,7 @@ class DirectCommandQueue final : public CommandQueue {
  public:
   DirectCommandQueue(VkDeviceHandle* logical_device,
                      iree_hal_command_category_t supported_categories,
-                     VkQueue queue);
+                     VkQueue queue, bool use_rgp);
   ~DirectCommandQueue() override;
 
   iree_status_t Submit(iree_host_size_t batch_count,
@@ -34,6 +34,7 @@ class DirectCommandQueue final : public CommandQueue {
   iree_status_t TranslateBatchInfo(
       const iree_hal_submission_batch_t* batch, VkSubmitInfo* submit_info,
       VkTimelineSemaphoreSubmitInfo* timeline_submit_info, Arena* arena);
+  bool enable_rgp;
 };
 
 }  // namespace vulkan

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
@@ -31,6 +31,9 @@ IREE_FLAG(int32_t, vulkan_debug_verbosity, 2,
 IREE_FLAG(bool, vulkan_tracing, true,
           "Enables Vulkan tracing (if IREE tracing is enabled).");
 
+IREE_FLAG(bool, enable_rgp, false,
+          "Wraps queue submits with debug labels for the rgp profiler");
+
 static iree_status_t iree_hal_vulkan_create_driver_with_flags(
     iree_string_view_t identifier, iree_allocator_t host_allocator,
     iree_hal_driver_t** out_driver) {
@@ -62,6 +65,10 @@ static iree_status_t iree_hal_vulkan_create_driver_with_flags(
   }
   if (FLAG_vulkan_tracing) {
     driver_options.requested_features |= IREE_HAL_VULKAN_FEATURE_ENABLE_TRACING;
+  }
+
+  if (FLAG_enable_rgp) {
+    driver_options.device_options.flags = 1u;
   }
 
   // Load the Vulkan library. This will fail if the library cannot be found or

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -430,12 +430,13 @@ static iree_status_t iree_hal_vulkan_create_transient_command_pool(
 static CommandQueue* iree_hal_vulkan_device_create_queue(
     VkDeviceHandle* logical_device,
     iree_hal_command_category_t command_category, uint32_t queue_family_index,
-    uint32_t queue_index) {
+    uint32_t queue_index, bool use_rgp) {
   VkQueue queue = VK_NULL_HANDLE;
   logical_device->syms()->vkGetDeviceQueue(*logical_device, queue_family_index,
                                            queue_index, &queue);
 
-  return new DirectCommandQueue(logical_device, command_category, queue);
+  return new DirectCommandQueue(logical_device, command_category, queue,
+                                use_rgp);
 }
 
 // Creates command queues for the given sets of queues and populates the
@@ -468,9 +469,11 @@ static iree_status_t iree_hal_vulkan_device_initialize_command_queues(
     iree_string_view_t queue_name =
         iree_make_string_view(queue_name_buffer, queue_name_length);
 
+    bool use_rgp = (bool)device->flags;
+
     CommandQueue* queue = iree_hal_vulkan_device_create_queue(
         device->logical_device, IREE_HAL_COMMAND_CATEGORY_ANY,
-        compute_queue_set->queue_family_index, i);
+        compute_queue_set->queue_family_index, i, use_rgp);
 
     iree_host_size_t queue_index = device->queue_count++;
     device->queues[queue_index] = queue;
@@ -506,9 +509,11 @@ static iree_status_t iree_hal_vulkan_device_initialize_command_queues(
     iree_string_view_t queue_name =
         iree_make_string_view(queue_name_buffer, queue_name_length);
 
+    bool use_rgp = (bool)device->flags;
+
     CommandQueue* queue = iree_hal_vulkan_device_create_queue(
         device->logical_device, IREE_HAL_COMMAND_CATEGORY_TRANSFER,
-        transfer_queue_set->queue_family_index, i);
+        transfer_queue_set->queue_family_index, i, use_rgp);
 
     iree_host_size_t queue_index = device->queue_count++;
     device->queues[queue_index] = queue;


### PR DESCRIPTION
This runs the module in a loop to allow for capturing an rgp trace and thus IREE benchmarking can't happen at the same time