### PR TITLE
Use memref.copy instead of linalg.generic for shared memory copy

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -60,7 +60,7 @@ static LogicalResult gpuCopyFn(OpBuilder &builder, Location loc, Value from,
       from.getType().cast<MemRefType>().getMemorySpaceAsInt() == 3 ||
       to.getType().cast<MemRefType>().getMemorySpaceAsInt() == 3;
   if (sharedMemCopy) builder.create<gpu::BarrierOp>(loc);
-  Operation *copy = createLinalgCopyOp(builder, loc, from, to);
+  Operation *copy = builder.create<memref::CopyOp>(loc, from, to);
   if (sharedMemCopy) {
     setMarker(copy, getCopyToWorkgroupMemoryMarker());
     builder.create<gpu::BarrierOp>(loc);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -87,7 +87,7 @@ static LogicalResult gpuCopyFn(OpBuilder &builder, Location loc, Value from,
   bool isWorkgroupMemory = fromType.getMemorySpaceAsInt() == workgroupSpace ||
                            toType.getMemorySpaceAsInt() == workgroupSpace;
   if (isWorkgroupMemory) builder.create<gpu::BarrierOp>(loc);
-  Operation *copy = createLinalgCopyOp(builder, loc, from, to);
+  Operation *copy = builder.create<memref::CopyOp>(loc, from, to);
   if (isWorkgroupMemory) {
     setMarker(copy, getCopyToWorkgroupMemoryMarker());
     builder.create<gpu::BarrierOp>(loc);


### PR DESCRIPTION
`linalg.generic` implements LinalgOp interface and may go through tiling path like other Linalg ops. This may have unexpected consequences---tiling and other marker-based patterns would handle the op and remove the `copy_to_workgroup_memory` marker before we reach GPUDistributeSharedMemory passs. And we will fail to distribute then.