### PR TITLE
[level_zero] Add support for creating device by UUID or ephemeral device ID

### DIFF
--- a/experimental/level_zero/direct_command_buffer.c
+++ b/experimental/level_zero/direct_command_buffer.c
@@ -242,7 +242,10 @@ static iree_status_t iree_hal_level_zero_direct_command_buffer_fill_buffer(
       iree_hal_level_zero_buffer_device_pointer(
           iree_hal_buffer_allocated_buffer(target_buffer));
   target_offset += iree_hal_buffer_byte_offset(target_buffer);
-  iree_hal_level_zero_device_ptr_t dst = target_device_buffer + target_offset;
+  iree_hal_level_zero_device_ptr_t dst =
+      (iree_hal_level_zero_device_ptr_t)((uintptr_t)(void*)
+                                             target_device_buffer +
+                                         target_offset);
   LEVEL_ZERO_RETURN_IF_ERROR(
       command_buffer->context->syms,
       zeCommandListAppendMemoryFill(command_buffer->command_list, dst, pattern,
@@ -275,8 +278,14 @@ static iree_status_t iree_hal_level_zero_direct_command_buffer_copy_buffer(
       iree_hal_level_zero_buffer_device_pointer(
           iree_hal_buffer_allocated_buffer(source_buffer));
   source_offset += iree_hal_buffer_byte_offset(source_buffer);
-  iree_hal_level_zero_device_ptr_t dst = target_device_buffer + target_offset;
-  iree_hal_level_zero_device_ptr_t src = source_device_buffer + source_offset;
+  iree_hal_level_zero_device_ptr_t dst =
+      (iree_hal_level_zero_device_ptr_t)((uintptr_t)(void*)
+                                             target_device_buffer +
+                                         target_offset);
+  iree_hal_level_zero_device_ptr_t src =
+      (iree_hal_level_zero_device_ptr_t)((uintptr_t)(void*)
+                                             source_device_buffer +
+                                         source_offset);
   // TODO(raikonenfnu): Currently using NULL stream, need to figure out way to
   // access proper stream from command buffer
   LEVEL_ZERO_RETURN_IF_ERROR(
@@ -345,9 +354,13 @@ iree_hal_level_zero_direct_command_buffer_push_descriptor_set(
     iree_hal_descriptor_set_binding_t binding = bindings[binding_used[i].index];
     iree_hal_level_zero_device_ptr_t device_ptr =
         binding.buffer
-            ? iree_hal_level_zero_buffer_device_pointer(
-                  iree_hal_buffer_allocated_buffer(binding.buffer)) +
-                  iree_hal_buffer_byte_offset(binding.buffer) + binding.offset
+            ? (iree_hal_level_zero_device_ptr_t)((uintptr_t)(void*)
+                                                     iree_hal_level_zero_buffer_device_pointer(
+                                                         iree_hal_buffer_allocated_buffer(
+                                                             binding.buffer)) +
+                                                 iree_hal_buffer_byte_offset(
+                                                     binding.buffer) +
+                                                 binding.offset)
             : 0;
     *((iree_hal_level_zero_device_ptr_t*)
           command_buffer->current_descriptor[i + base_binding]) = device_ptr;

--- a/experimental/level_zero/status_util.h
+++ b/experimental/level_zero/status_util.h
@@ -48,6 +48,14 @@ iree_status_t iree_hal_level_zero_result_to_status(
     iree_hal_level_zero_dynamic_symbols_t* syms, ze_result_t result,
     const char* file, uint32_t line);
 
+#define IREE_LEVEL_ZERO_TRY(...)      \
+  do {                                \
+    status = __VA_ARGS__;             \
+    if (!iree_status_is_ok(status)) { \
+      goto cleanup;                   \
+    }                                 \
+  } while (0)
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/experimental/level_zero/test/CMakeLists.txt
+++ b/experimental/level_zero/test/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_add_all_subdirs()
+
+iree_cc_test(
+  NAME
+    level_zero_test
+  SRCS
+    level_zero_test.cc
+  DEPS
+    iree::runtime
+    iree::testing::gtest
+    iree::testing::gtest_main
+  PUBLIC
+)

--- a/experimental/level_zero/test/level_zero_test.cc
+++ b/experimental/level_zero/test/level_zero_test.cc
@@ -1,0 +1,86 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <iree/runtime/api.h>
+#include <iree/testing/gtest.h>
+
+#include <memory>
+#include <sstream>
+#include <string>
+
+template <typename T, typename Deleter>
+std::unique_ptr<T, Deleter> make_unique(T* p, Deleter d) {
+  return std::unique_ptr<T, Deleter>(p, d);
+}
+
+TEST(LevelZeroTest, UUID) {
+  iree_runtime_instance_options_t instance_options;
+  iree_runtime_instance_options_initialize(&instance_options);
+  iree_runtime_instance_options_use_all_available_drivers(&instance_options);
+
+  static const char* driver_name = "level_zero";
+
+  iree_allocator_t host_allocator = iree_allocator_system();
+
+  // Make instance.
+  iree_runtime_instance_t* instance = nullptr;
+  ASSERT_EQ(iree_runtime_instance_create(&instance_options,
+                                         iree_allocator_system(), &instance),
+            iree_ok_status());
+  auto instance_deleter = make_unique<iree_runtime_instance_t>(
+      instance,
+      [](iree_runtime_instance_t* p) { iree_runtime_instance_release(p); });
+
+  // Make Level Zero driver.
+  iree_hal_driver_registry_t* driver_registry =
+      iree_runtime_instance_driver_registry(instance);
+  iree_hal_driver_t* driver = nullptr;
+  ASSERT_EQ(iree_hal_driver_registry_try_create(
+                driver_registry, iree_make_cstring_view(driver_name),
+                host_allocator, &driver),
+            iree_ok_status());
+  auto driver_deleter = make_unique<iree_hal_driver_t>(
+      driver, [](iree_hal_driver_t* p) { iree_hal_driver_release(p); });
+
+  // Get list of available devices.
+  iree_hal_device_info_t* device_infos = nullptr;
+  iree_host_size_t device_infos_count = 0;
+  ASSERT_EQ(iree_hal_driver_query_available_devices(
+                driver, host_allocator, &device_infos_count, &device_infos),
+            iree_ok_status());
+  auto device_infos_deleter = make_unique<iree_hal_device_info_t>(
+      device_infos, [host_allocator](iree_hal_device_info_t* p) {
+        iree_allocator_free(host_allocator, p);
+      });
+  ASSERT_GT(device_infos_count, 0);
+
+  // Create a valid device from URI.
+  std::stringstream device_uri;
+  device_uri << driver_name << "://";
+  device_uri << std::string(device_infos[0].path.data,
+                            device_infos[0].path.size);
+  std::string device_uri_str = device_uri.str();
+  iree_hal_device_t* device = nullptr;
+  ASSERT_EQ(iree_hal_driver_create_device_by_uri(
+                driver, iree_make_cstring_view(device_uri_str.c_str()),
+                host_allocator, &device),
+            iree_ok_status());
+  auto device_deleter = make_unique<iree_hal_device_t>(
+      device, [](iree_hal_device_t* p) { iree_hal_device_release(p); });
+
+  // Try create an invalid device from URI.
+  std::stringstream invalid_device_uri;
+  invalid_device_uri << driver_name
+                     << "://4e5a272e-66a7-11ed-9342-4f1f581f812c";
+  std::string invalid_device_uri_str = invalid_device_uri.str();
+  iree_hal_device_t* invalid_device = nullptr;
+  ASSERT_NE(iree_hal_driver_create_device_by_uri(
+                driver, iree_make_cstring_view(invalid_device_uri_str.c_str()),
+                host_allocator, &invalid_device),
+            iree_ok_status());
+  auto invalid_device_deleter = make_unique<iree_hal_device_t>(
+      invalid_device, [](iree_hal_device_t* p) { iree_hal_device_release(p); });
+}


### PR DESCRIPTION
With this change you can do

```    
$ iree-run-module --list_devices
level_zero://00005100-0000-0000-0000-000000000001

$ iree-run-module --device=level_zero://00005100-0000-0000-0000-000000000001 ...
```