### PR TITLE
[level_zero] Supply structure type when passing such arguments in accordance with the API

### DIFF
--- a/experimental/level_zero/direct_command_buffer.c
+++ b/experimental/level_zero/direct_command_buffer.c
@@ -92,7 +92,8 @@ iree_status_t iree_hal_level_zero_direct_command_buffer_create(
     }
     // Create a command list
     ze_command_list_handle_t command_list;
-    ze_command_list_desc_t command_list_desc = {};
+    ze_command_list_desc_t command_list_desc = {
+        .stype = ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC};
     command_list_desc.commandQueueGroupOrdinal = command_queue_ordinal;
     LEVEL_ZERO_RETURN_IF_ERROR(
         command_buffer->context->syms,
@@ -184,7 +185,8 @@ static iree_status_t iree_hal_level_zero_direct_command_buffer_signal_event(
       iree_hal_level_zero_direct_command_buffer_cast(base_command_buffer);
   LEVEL_ZERO_RETURN_IF_ERROR(
       command_buffer->context->syms,
-      zeCommandListAppendSignalEvent(command_buffer->command_list, iree_hal_level_zero_event_handle(event)),
+      zeCommandListAppendSignalEvent(command_buffer->command_list,
+                                     iree_hal_level_zero_event_handle(event)),
       "zeCommandListAppendSignalEvent");
   return iree_ok_status();
 }
@@ -196,7 +198,8 @@ static iree_status_t iree_hal_level_zero_direct_command_buffer_reset_event(
       iree_hal_level_zero_direct_command_buffer_cast(base_command_buffer);
   LEVEL_ZERO_RETURN_IF_ERROR(
       command_buffer->context->syms,
-      zeCommandListAppendEventReset(command_buffer->command_list, iree_hal_level_zero_event_handle(event)),
+      zeCommandListAppendEventReset(command_buffer->command_list,
+                                    iree_hal_level_zero_event_handle(event)),
       "zeCommandListAppendEventReset");
   return iree_ok_status();
 }
@@ -212,14 +215,16 @@ static iree_status_t iree_hal_level_zero_direct_command_buffer_wait_events(
     const iree_hal_buffer_barrier_t* buffer_barriers) {
   iree_hal_level_zero_direct_command_buffer_t* command_buffer =
       iree_hal_level_zero_direct_command_buffer_cast(base_command_buffer);
-  iree_inline_array(ze_event_handle_t, event_handles, event_count, command_buffer->context->host_allocator);
+  iree_inline_array(ze_event_handle_t, event_handles, event_count,
+                    command_buffer->context->host_allocator);
   for (int i = 0; i < event_count; ++i) {
     *iree_inline_array_at(event_handles, i) =
         iree_hal_level_zero_event_handle(events[i]);
   }
   LEVEL_ZERO_RETURN_IF_ERROR(
       command_buffer->context->syms,
-      zeCommandListAppendWaitOnEvents(command_buffer->command_list, event_count, iree_inline_array_data(event_handles)),
+      zeCommandListAppendWaitOnEvents(command_buffer->command_list, event_count,
+                                      iree_inline_array_data(event_handles)),
       "zeCommandListAppendWaitOnEvents");
   return iree_ok_status();
 }

--- a/experimental/level_zero/dynamic_symbols_test.cc
+++ b/experimental/level_zero/dynamic_symbols_test.cc
@@ -65,7 +65,8 @@ TEST(DynamicSymbolsTest, CreateFromSystemLoader) {
   }
 
   // Print basic properties of the device
-  ze_device_properties_t deviceProperties = {};
+  ze_device_properties_t deviceProperties = {
+      .stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES};
   LEVEL_ZERO_CHECK_ERRORS(
       symbols.zeDeviceGetProperties(device, &deviceProperties));
   std::cout << "Device   : " << deviceProperties.name << "\n"

--- a/experimental/level_zero/level_zero_driver.c
+++ b/experimental/level_zero/level_zero_driver.c
@@ -123,7 +123,8 @@ IREE_API_EXPORT iree_status_t iree_hal_level_zero_driver_create(
 static uint8_t* iree_hal_level_zero_populate_device_info(
     ze_device_handle_t device, iree_hal_level_zero_dynamic_symbols_t* syms,
     uint8_t* buffer_ptr, iree_hal_device_info_t* out_device_info) {
-  ze_device_properties_t deviceProperties = {};
+  ze_device_properties_t deviceProperties = {
+      .stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES};
   LEVEL_ZERO_IGNORE_ERROR(syms,
                           zeDeviceGetProperties(device, &deviceProperties));
   memset(out_device_info, 0, sizeof(*out_device_info));
@@ -306,7 +307,8 @@ static iree_status_t iree_hal_level_zero_driver_create_device_by_uuid(
   // Find the Level Zero device with the given UUID.
   bool is_device_found = false;
   for (uint32_t i = 0; i < device_count; ++i) {
-    ze_device_properties_t device_properties;
+    ze_device_properties_t device_properties = {
+        .stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES};
     IREE_LEVEL_ZERO_TRY(LEVEL_ZERO_RESULT_TO_STATUS(
         &driver->syms, zeDeviceGetProperties(ze_devices[i], &device_properties),
         "zeDeviceGetProperties"));

--- a/experimental/level_zero/native_executable.c
+++ b/experimental/level_zero/native_executable.c
@@ -84,6 +84,7 @@ iree_status_t iree_hal_level_zero_native_executable_create(
   ze_module_build_log_handle_t build_log;
   if (iree_status_is_ok(status)) {
     ze_module_desc_t module_desc = {};
+    module_desc.stype = ZE_STRUCTURE_TYPE_MODULE_DESC;
     module_desc.format = ZE_MODULE_FORMAT_IL_SPIRV;
     iree_const_byte_span_t code = iree_make_const_byte_span(
         level_zero_image,
@@ -101,7 +102,7 @@ iree_status_t iree_hal_level_zero_native_executable_create(
     if (iree_status_is_ok(status)) {
       const char* entry_name = flatbuffers_string_vec_at(entry_points_vec, i);
       ze_kernel_handle_t function = NULL;
-      ze_kernel_desc_t kernel_desc = {};
+      ze_kernel_desc_t kernel_desc = {.stype = ZE_STRUCTURE_TYPE_KERNEL_DESC};
       // kernel_desc.pKernelName = "simple_mul_dispatch_0";
       kernel_desc.pKernelName = entry_name;
       LEVEL_ZERO_RETURN_IF_ERROR(


### PR DESCRIPTION
When calling Level Zero API functions that query information and use a struct to populate the information, the user must supply the structure type (stype) in the structure itself. The struct is both in and out argument.