### PR TITLE
[level_zero] Supply structure type when passing such arguments in accordance with the API (reopen)

### DIFF
--- a/experimental/level_zero/level_zero_driver.c
+++ b/experimental/level_zero/level_zero_driver.c
@@ -307,7 +307,8 @@ static iree_status_t iree_hal_level_zero_driver_create_device_by_uuid(
   // Find the Level Zero device with the given UUID.
   bool is_device_found = false;
   for (uint32_t i = 0; i < device_count; ++i) {
-    ze_device_properties_t device_properties;
+    ze_device_properties_t device_properties = {
+        .stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES};
     IREE_LEVEL_ZERO_TRY(LEVEL_ZERO_RESULT_TO_STATUS(
         &driver->syms, zeDeviceGetProperties(ze_devices[i], &device_properties),
         "zeDeviceGetProperties"));


### PR DESCRIPTION
When calling Level Zero API functions that query information and use a struct to populate the information, the user must supply the structure type (stype) in the structure itself. The struct is both in and out argument.

This is a reopening of https://github.com/nod-ai/SHARK-Runtime/pull/29 that was merged but got lost maybe because of a forced rebase.