### PR TITLE
[CI] Do not force push into shark if the HEAD has changed

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -66,4 +66,4 @@ jobs:
           github_token: ${{ secrets.CI_WRITE_TOKEN }}
           branch: shark
           repository: nod-ai/shark-runtime
-          force: true
+          force_with_lease: true


### PR DESCRIPTION
This fixes the problem of potentially dropping commits that have been submitted while an automatic rebase with upstream IREE is goining on.

See: https://git-scm.com/docs/git-push#Documentation/git-push.txt---no-force-with-lease
See: https://github.com/ad-m/github-push-action