### PR TITLE
Update array_interop.py

### DIFF
--- a/runtime/bindings/python/iree/runtime/array_interop.py
+++ b/runtime/bindings/python/iree/runtime/array_interop.py
@@ -208,8 +208,8 @@ def asdevicearray(device: HalDevice,
     # device, so transfer back to the host.
     logging.warn(
         "Implicit dtype conversion of a DeviceArray forces a host transfer")
-  # First get an ndarray.
-  a = np.asarray(a, dtype=dtype)
+  # First get an ndarray. Needs to be C-contiguous, enforcing it here.
+  a = np.asarray(a, dtype=dtype, order="C")
   element_type = map_dtype_to_element_type(a.dtype)
   if element_type is None:
     raise ValueError(f"Could not map dtype {a.dtype} to IREE element type")


### PR DESCRIPTION
Needed to eliminate:
```
  File "...SHARK\shark\iree_utils\compile_utils.py", line 380, in <listcomp>
    device_inputs = [ireert.asdevicearray(config.device, a) for a in input]
  File "...iree\runtime\array_interop.py", line 216, in asdevicearray
    buffer_view = device.allocator.allocate_buffer_copy(
ValueError: ndarray is not C-contiguous
```

Since C-contiguous array is expected here, we enforce it in the steps before.