### PR TITLE
Revert "In Python bindings always use caching allocator when creating a device"

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -52,7 +52,6 @@ iree_pyext_module(
     iree::base::tracing
     iree::hal
     iree::hal::drivers
-    iree::hal::utils::caching_allocator
     iree::modules::hal
     iree::vm
     iree::vm::bytecode_module

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -10,7 +10,6 @@
 #include "iree/base/internal/path.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/api.h"
-#include "iree/hal/utils/caching_allocator.h"
 #include "iree/modules/hal/module.h"
 #include "pybind11/numpy.h"
 
@@ -313,24 +312,11 @@ py::list HalDriver::QueryAvailableDevices() {
   return results;
 }
 
-namespace {
-void ReplaceWithCatchingAllocator(iree_hal_device_t* device) {
-  iree_hal_allocator_t* base_allocator = iree_hal_device_allocator(device);
-  iree_hal_allocator_t* wrapped_allocator = NULL;
-  IREE_CHECK_OK(iree_hal_caching_allocator_create_unbounded(
-      base_allocator, iree_hal_allocator_host_allocator(base_allocator),
-      &wrapped_allocator));
-  iree_hal_device_replace_allocator(device, wrapped_allocator);
-  iree_hal_allocator_release(wrapped_allocator);
-}
-}  // namespace
-
 HalDevice HalDriver::CreateDefaultDevice() {
   iree_hal_device_t* device;
   CheckApiStatus(iree_hal_driver_create_default_device(
                      raw_ptr(), iree_allocator_system(), &device),
                  "Error creating default device");
-  ReplaceWithCatchingAllocator(device);
   return HalDevice::StealFromRawPtr(device);
 }
 
@@ -366,7 +352,6 @@ HalDevice HalDriver::CreateDevice(iree_hal_device_id_t device_id) {
                      raw_ptr(), device_id, params.size(), &params.front(),
                      iree_allocator_system(), &device),
                  "Error creating default device");
-  ReplaceWithCatchingAllocator(device);
   return HalDevice::StealFromRawPtr(device);
 }
 
@@ -377,7 +362,6 @@ HalDevice HalDriver::CreateDeviceByURI(std::string& device_uri) {
       iree_hal_driver_create_device_by_uri(raw_ptr(), device_uri_sv,
                                            iree_allocator_system(), &device),
       "Error creating device");
-  ReplaceWithCatchingAllocator(device);
   return HalDevice::StealFromRawPtr(device);
 }
 


### PR DESCRIPTION
This reverts commit d2a8556cca73c8cb96fffe778ceb92832be289cd.