### PR TITLE
[split_mlir] Add operation list extraction and execution for IREE

### DIFF
--- a/experimental/split_mlir/src/iree/split_mlir/CMakeLists.txt
+++ b/experimental/split_mlir/src/iree/split_mlir/CMakeLists.txt
@@ -54,3 +54,31 @@ iree_compiler_register_plugin(
   TARGET
     ::registration
 )
+
+iree_pyext_module(
+  NAME
+    PyExt
+  MODULE_NAME _split_mlir
+  SRCS
+    "OperationListImpl.h"
+    "SplitMlirPyExt.cpp"
+  DEPS
+    MLIRFuncDialect
+    MLIRIR
+    MLIRAsmParser
+    iree::compiler::Tools::init_passes_and_dialects
+)
+
+iree_py_library(
+  NAME
+    split_mlir_py
+  SRCS
+    "__init__.py"
+    "_split_mlir.pyi"
+    "execution.py"
+    "iree_execution.py"
+    "types.py"
+  DEPS
+    MLIRPythonModules
+    ::PyExt
+)

--- a/experimental/split_mlir/src/iree/split_mlir/OperationListImpl.h
+++ b/experimental/split_mlir/src/iree/split_mlir/OperationListImpl.h
@@ -1,0 +1,181 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "iree/compiler/Tools/init_dialects.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/SourceMgr.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir {
+namespace iree {
+namespace split_mlir {
+
+using OpId = std::string;
+using OpIndex = size_t;
+using ResultIndex = size_t;
+using ResultId = std::tuple<OpIndex, ResultIndex>;
+using Arguments = std::vector<ResultId>;
+using OperationList = std::vector<std::tuple<OpId, Arguments>>;
+
+ResultIndex getResultIndex(OpOperand& operand) {
+  OpResult opResult = operand.get().dyn_cast<OpResult>();
+  if (opResult) {
+    return opResult.getResultNumber();
+  }
+
+  BlockArgument blockArgument = operand.get().dyn_cast<BlockArgument>();
+  assert(blockArgument);
+  return blockArgument.getArgNumber();
+}
+
+FailureOr<OpIndex> getDefiningOpIndex(
+    OpOperand& operand, Block& block,
+    const std::unordered_map<Operation*, size_t>& operationInBlockIndexMap) {
+  Value value = operand.get();
+  if (value.isa<BlockArgument>()) {
+    return 0;
+  }
+
+  OpResult opResult = value.dyn_cast<OpResult>();
+  if (!opResult) {
+    operand.getOwner()->emitError(
+        Twine("Operand ") + std::to_string(operand.getOperandNumber()) +
+        "is  neigher a block argument or a result of an operation");
+    return failure();
+  }
+  if (value.getDefiningOp()->getBlock() != &block) {
+    operand.getOwner()->emitError(
+        "Can't extract call graph for block that is not isolated from above.");
+    return failure();
+  }
+
+  auto it = operationInBlockIndexMap.find(value.getDefiningOp());
+  assert(it != operationInBlockIndexMap.end());
+  return it->second;
+}
+
+std::string getOpId(Operation& op) {
+  func::CallOp callOp = dyn_cast<func::CallOp>(op);
+  if (callOp) {
+    return (Twine("call ") + callOp.getCallee()).str();
+  }
+
+  if (isa<func::ReturnOp>(op)) {
+    return "return";
+  }
+
+  return op.getName().getStringRef().str();
+}
+
+FailureOr<OperationList> extractOperationList(Block& block) {
+  OperationList res;
+  // Block arguments don't depend on anything.
+  res.emplace_back();
+  // Index inside the block.
+  std::unordered_map<Operation*, size_t> operationInBlockIndexMap;
+
+  for (auto opIt : llvm::enumerate(block)) {
+    operationInBlockIndexMap.insert({&opIt.value(), opIt.index() + 1});
+    OpId id = getOpId(opIt.value());
+    Arguments arguments;
+    for (OpOperand& operand : opIt.value().getOpOperands()) {
+      FailureOr<OpIndex> opIndex =
+          getDefiningOpIndex(operand, block, operationInBlockIndexMap);
+      FailureOr<ResultIndex> resultIndex = getResultIndex(operand);
+      if (failed(opIndex) || failed(resultIndex)) {
+        return failure();
+      }
+      arguments.emplace_back(opIndex.value(), resultIndex.value());
+    }
+    res.emplace_back(id, arguments);
+  }
+
+  return res;
+}
+
+FailureOr<OwningOpRef<ModuleOp>> loadMlir(const char* mlirFilePath,
+                                          MLIRContext& context) {
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> fileOrErr =
+      llvm::MemoryBuffer::getFileOrSTDIN(mlirFilePath);
+  if (std::error_code ec = fileOrErr.getError()) {
+    llvm::errs() << "Could not open input file: " << ec.message() << "\n";
+    return failure();
+  }
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), llvm::SMLoc());
+  return parseSourceFile<ModuleOp>(sourceMgr, &context);
+}
+
+func::FuncOp findFunction(Operation* root, StringRef name) {
+  func::FuncOp res;
+  root->walk([&](func::FuncOp op) {
+    if (op.getSymName() == name) {
+      res = op;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return res;
+}
+
+FailureOr<OperationList> extractOperationList(ModuleOp moduleOp,
+                                              StringRef functionName) {
+  func::FuncOp funcOp = findFunction(moduleOp.getOperation(), functionName);
+  Region* region = funcOp.getCallableRegion();
+  if (!region) {
+    funcOp.emitError("No callable region found.");
+    return failure();
+  }
+  if (region->getBlocks().size() != 1) {
+    funcOp.emitError("Blocks count must be exactly 1.");
+    return failure();
+  }
+  return extractOperationList(region->front());
+}
+
+FailureOr<OperationList> extractOperationList(const char* mlirFilePath,
+                                              StringRef functionName,
+                                              MLIRContext& context) {
+  auto moduleOp = loadMlir(mlirFilePath, context);
+  if (failed(moduleOp)) {
+    return failure();
+  }
+
+  return extractOperationList(moduleOp->get(), functionName);
+}
+
+std::unique_ptr<mlir::MLIRContext> makeMlirContext() {
+  mlir::DialectRegistry registry;
+  mlir::iree_compiler::registerAllDialects(registry);
+  auto context = std::make_unique<mlir::MLIRContext>(registry);
+  return context;
+}
+
+FailureOr<OperationList> extractOperationList(const char* mlirFilePath,
+                                              StringRef functionName) {
+  auto context = makeMlirContext();
+  return extractOperationList(mlirFilePath, functionName, *context);
+}
+
+}  // namespace split_mlir
+}  // namespace iree
+}  // namespace mlir

--- a/experimental/split_mlir/src/iree/split_mlir/SplitMlirPyExt.cpp
+++ b/experimental/split_mlir/src/iree/split_mlir/SplitMlirPyExt.cpp
@@ -1,0 +1,37 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <stdexcept>
+
+#include "OperationListImpl.h"
+
+namespace py = pybind11;
+
+namespace mlir {
+namespace iree {
+namespace split_mlir {
+
+PYBIND11_MODULE(_split_mlir, m) {
+  m.doc() = "Split MLIR C++ extension";
+
+  m.def(
+      "extract_operation_list",
+      [](const std::string& mlirFilePath, const std::string& functionName) {
+        auto res = extractOperationList(mlirFilePath.c_str(), functionName);
+        if (failed(res)) {
+          throw std::runtime_error("");
+        }
+        return res.value();
+      },
+      py::arg("mlir_file_path"), py::arg("function_name"));
+}
+
+}  // namespace split_mlir
+}  // namespace iree
+}  // namespace mlir

--- a/experimental/split_mlir/src/iree/split_mlir/__init__.py
+++ b/experimental/split_mlir/src/iree/split_mlir/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._split_mlir import extract_operation_list
+from .execution import execute_operation_list
+from .iree_execution import IreeExecutor, execute_mlir_with_iree
+
+__all__ = [
+    "execute_operation_list", "execute_mlir_with_iree",
+    "extract_operation_list", "IreeExecutor"
+]

--- a/experimental/split_mlir/src/iree/split_mlir/_split_mlir.pyi
+++ b/experimental/split_mlir/src/iree/split_mlir/_split_mlir.pyi
@@ -1,0 +1,12 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from .types import OperationList
+
+
+def extract_operation_list(mlir_file_path: str,
+                           function_name: str) -> OperationList:
+  ...

--- a/experimental/split_mlir/src/iree/split_mlir/execution.py
+++ b/experimental/split_mlir/src/iree/split_mlir/execution.py
@@ -1,0 +1,42 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import List, Optional
+from .types import OpArguments, Tensor, ExecuteOp, OperationList
+
+
+def collect_arguments(arguments: OpArguments,
+                      results: List[List[Tensor]]) -> List[Tensor]:
+  return [results[arg[0]][arg[1]] for arg in arguments]  # type: ignore
+
+
+def execute_operation_list(
+    input: List[Tensor],
+    operation_list: OperationList,
+    execute_op: ExecuteOp,
+    override_results: Optional[List[List[Tensor]]] = None
+) -> List[List[Tensor]]:
+  """Algorithm to execute a call list.
+
+  Parameters
+  ----------
+  input : Input of the graph.
+  execute_op : Callable that executes an operation from the graph.
+  override_results : When execting operations override arguments with this values,
+    instead of using the computed resuts from previous functions.
+  
+  Returns
+  -------
+  All results from all operations is the graph are in the same order
+  as they appear in `operation_list`. `input` is prepened to the result.
+  """
+  results = [input]
+  for op in operation_list[1:]:
+    arguments = collect_arguments(
+        arguments=op[1],
+        results=results if override_results is None else override_results)
+    results.append(execute_op(op[0], arguments))
+  return results

--- a/experimental/split_mlir/src/iree/split_mlir/iree_execution.py
+++ b/experimental/split_mlir/src/iree/split_mlir/iree_execution.py
@@ -1,0 +1,122 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import List, Callable, Tuple, Dict, Optional, Any
+from .types import Tensor
+import iree.runtime
+from iree.runtime import VmModule, HalDevice, load_vm_module
+from .execution import execute_operation_list
+from tempfile import TemporaryDirectory
+from iree.compiler.tools import compile_file
+import os
+from pathlib import Path
+from collections import namedtuple
+from ._split_mlir import extract_operation_list
+from numbers import Number
+
+VmfbFilePath = str
+MlirFilePath = str
+FunctionName = str
+
+
+class IreeExecutor:
+  """Executor for IREE that implements the `.types.ExecuteOp` interface."""
+
+  def __init__(self, device: HalDevice,
+               resolve_function: Callable[[FunctionName], Tuple[VmfbFilePath,
+                                                                FunctionName]]):
+    """
+    Parameters
+    ----------
+    resolve_function : Resolves a function name that is called in the entry MLIR to
+      the vmfb file where it can be found under another name.
+    """
+    self.device = device
+    self.resolve_function = resolve_function
+
+  def __call__(self, op_id: str, operands: List[Tensor]) -> List[Tensor]:
+    if op_id.startswith("call "):
+      function_name = op_id.split(" ", 2)[1]
+      vmfb_file_path, vmfb_function_name = self.resolve_function(function_name)
+      config = iree.runtime.Config(device=self.device)
+      with open(vmfb_file_path, "rb") as f:
+        vm_flatbuffer = f.read()
+      vm_module_fb_bytes = VmModule.from_flatbuffer(config.vm_instance,
+                                                    vm_flatbuffer)
+      vm_module = load_vm_module(vm_module_fb_bytes, config)
+      res = getattr(vm_module, vmfb_function_name)(*operands)
+      if isinstance(res, (iree.runtime.DeviceArray, Number)):
+        res = [res]
+      return res
+    if op_id == "return":
+      return operands
+    raise RuntimeError(f"Invalid op_id \"{op_id}\".")
+
+
+def mlir_to_vmfb_file_path(mlir_file_path: str) -> str:
+  return f"{Path(mlir_file_path).stem}.vmfb"
+
+
+def execute_mlir_with_iree(input: List[Tensor],
+                           mlir_path_function_pairs: List[Tuple[MlirFilePath,
+                                                                FunctionName]],
+                           compile_kwargs: Dict[str, Any],
+                           device: HalDevice,
+                           override_results: Optional[List[
+                               List[Tensor]]] = None,
+                           artifact_dir: Optional[str] = None) -> List[Tensor]:
+  """Executes an MLIR program that is split accorss multiple MLIR files.
+  Parameters
+  ----------
+  mlir_path_function_pairs : List of MLIR files and the function they contain.
+    The first element is the entry MLIR and function.
+    It is expected that a name of function called in the entry function correspnd
+    to an MLIR file with the same name without file name extension.
+  compile_kwargs : Compile arguments to pass to iree.compiler.tools.compile_file.
+  artifact_dir : Where to put temporary files.
+    Defaults to creating a unique temporary directory that is deleted on completion.
+
+  See: `execute_operation_list`
+  """
+  if artifact_dir is None:
+    with TemporaryDirectory() as temp_dir:
+      return execute_mlir_with_iree(
+          input=input,
+          mlir_path_function_pairs=mlir_path_function_pairs,
+          override_results=override_results,
+          compile_kwargs=compile_kwargs,
+          device=device,
+          artifact_dir=temp_dir)
+
+  entry_mlir_file_path = mlir_path_function_pairs[0][0]
+  entry_function_name = mlir_path_function_pairs[0][1]
+  FunctionDescription = namedtuple(
+      "FunctionDescription",
+      ["mlir_file_path", "vmfb_file_path", "function_name"])
+  function_map = {
+      Path(Path(p[0]).name).stem: FunctionDescription(
+          p[0], os.path.join(artifact_dir, mlir_to_vmfb_file_path(p[0])), p[1])
+      for p in mlir_path_function_pairs
+  }
+  for i in range(1, len(mlir_path_function_pairs)):
+    function_description = function_map[Path(
+        Path(mlir_path_function_pairs[i][0]).name).stem]
+    compile_file(function_description.mlir_file_path,
+                 output_file=function_description.vmfb_file_path,
+                 **compile_kwargs)
+
+  def resolve_function(
+      function_name: FunctionName) -> Tuple[VmfbFilePath, FunctionName]:
+    func_desc = function_map[function_name]
+    return (func_desc.vmfb_file_path, func_desc.function_name)
+
+  executor = IreeExecutor(device=device, resolve_function=resolve_function)
+  operation_list = extract_operation_list(mlir_file_path=entry_mlir_file_path,
+                                          function_name=entry_function_name)
+  return execute_operation_list(operation_list=operation_list,
+                                execute_op=executor,
+                                input=input,
+                                override_results=override_results)

--- a/experimental/split_mlir/src/iree/split_mlir/test/execution/CMakeLists.txt
+++ b/experimental/split_mlir/src/iree/split_mlir/test/execution/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_add_all_subdirs()
+
+iree_local_py_test(
+  NAME
+    execution_test
+  SRC
+    execution_test.py
+  PACKAGE_DIRS
+  "${IREE_BINARY_DIR}/compiler/bindings/python"
+  "${IREE_BINARY_DIR}/runtime/bindings/python"
+  "${IREE_BINARY_DIR}/compiler/plugins/split_mlir"
+)

--- a/experimental/split_mlir/src/iree/split_mlir/test/execution/entry.mlir
+++ b/experimental/split_mlir/src/iree/split_mlir/test/execution/entry.mlir
@@ -1,0 +1,14 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+func.func nested @f1(%arg0: tensor<1xf32>, %arg1: tensor<1xf32>) -> (tensor<1xf32>, tensor<1xf32>)
+func.func nested @f2(%arg0: tensor<1xf32>) -> tensor<1xf32>
+
+func.func @caller(%arg0: tensor<1xf32>, %arg1: tensor<1xf32>) -> (tensor<1xf32>, tensor<1xf32>) {
+  %0:2 = call @f1(%arg0, %arg0) : (tensor<1xf32>, tensor<1xf32>) -> (tensor<1xf32>, tensor<1xf32>)
+  %1 = call @f2(%0#0) : (tensor<1xf32>) -> tensor<1xf32>
+  return %arg1, %1 : tensor<1xf32>, tensor<1xf32>
+}

--- a/experimental/split_mlir/src/iree/split_mlir/test/execution/execution_test.py
+++ b/experimental/split_mlir/src/iree/split_mlir/test/execution/execution_test.py
@@ -1,0 +1,57 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+from iree.split_mlir import extract_operation_list, execute_mlir_with_iree
+from typing import List, Any
+import os
+import iree.runtime
+import numpy as np
+
+
+def assert_nested_array_equals(a: List[Any], b: List[Any]):
+  assert a == b, f"{a} != {b}"
+
+
+class ExecutionTest(unittest.TestCase):
+
+  def test_extract_operation_list(self):
+    expected_operation_list = [
+        ("", []),
+        ("call f1", [(0, 0), (0, 0)]),
+        ("call f2", [(1, 0)]),
+        ("return", [(0, 1), (2, 0)]),
+    ]
+    operation_list = extract_operation_list(mlir_file_path=os.path.join(
+        os.path.dirname(__file__), "entry.mlir"),
+                                            function_name="caller")
+    assert_nested_array_equals(expected_operation_list, operation_list)
+
+  def test_mlir_execution(self):
+    mlir_path_function_pairs = [
+        (os.path.join(os.path.dirname(__file__), "entry.mlir"), "caller"),
+        (os.path.join(os.path.dirname(__file__), "f1.mlir"), "f1"),
+        (os.path.join(os.path.dirname(__file__), "f2.mlir"), "main"),
+    ]
+    compile_kwargs = {
+        "target_backends": ["llvm-cpu"],
+    }
+    device = iree.runtime.get_device("local-task")
+    input = [np.array([1], dtype=np.float32), np.array([2], dtype=np.float32)]
+    results = execute_mlir_with_iree(
+        input=input,
+        mlir_path_function_pairs=mlir_path_function_pairs,
+        compile_kwargs=compile_kwargs,
+        device=device)
+    expected_output = [
+        np.array([2], dtype=np.float32),
+        np.array([4], dtype=np.float32)
+    ]
+    assert_nested_array_equals(results[-1], expected_output)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/experimental/split_mlir/src/iree/split_mlir/test/execution/f1.mlir
+++ b/experimental/split_mlir/src/iree/split_mlir/test/execution/f1.mlir
@@ -1,0 +1,10 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+func.func @f1(%arg0: tensor<1xf32>, %arg1: tensor<1xf32>) -> (tensor<1xf32>, tensor<1xf32>) {
+  %0 = arith.addf %arg0, %arg1: tensor<1xf32>
+  return %0, %0 : tensor<1xf32>, tensor<1xf32>
+}

--- a/experimental/split_mlir/src/iree/split_mlir/test/execution/f2.mlir
+++ b/experimental/split_mlir/src/iree/split_mlir/test/execution/f2.mlir
@@ -1,0 +1,10 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+func.func @main(%arg0: tensor<1xf32>) -> tensor<1xf32> {
+  %0 = arith.addf %arg0, %arg0 : tensor<1xf32>
+  return %0 : tensor<1xf32>
+}

--- a/experimental/split_mlir/src/iree/split_mlir/types.py
+++ b/experimental/split_mlir/src/iree/split_mlir/types.py
@@ -1,0 +1,19 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import List, TypeVar, Callable, Tuple
+from numbers import Integral
+
+Tensor = TypeVar("Tensor")
+OpId = TypeVar("OpId")
+ExecuteOp = Callable[[OpId, List[Tensor]], List[Tensor]]
+OperationIndex = Integral
+ResultIndex = Integral
+"""Description of the dependencies of an operation."""
+OpArguments = List[Tuple[OperationIndex, ResultIndex]]
+Operation = Tuple[OpId, OpArguments]
+"""Describes a dependency graph of operations."""
+OperationList = List[Operation]


### PR DESCRIPTION
Expose a Python binding that has extraction of an
operation list from an MLIR file.
This list is then used to execute with IREE the
entry MLIR while resolving calls to functions in
other MLIR files.