### PR TITLE
Switch for llvm-cpu instead of vmvx for const-eval

### DIFF
--- a/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
+++ b/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
@@ -135,7 +135,7 @@ struct JitGlobalsPass : public JitGlobalsBase<JitGlobalsPass> {
       : options(std::make_shared<CompileOptions>()),
         compilePipeline("builtin.module") {
     // Invoke IREE compilation flow.
-    options->executableOptions.targets.push_back("vmvx");
+    options->executableOptions.targets.push_back("llvm-cpu");
     options->targetOptions.f32Extension = true;
     options->targetOptions.f64Extension = false;  // not yet implemented
 


### PR DESCRIPTION
Observed correctness errors with vmvx for const-eval with int8 types so use llvm-cpu instead for now.

Creating this PR as a log of the commit.